### PR TITLE
feat: 댓글기능 구현

### DIFF
--- a/src/Review/MovieDetail.jsx
+++ b/src/Review/MovieDetail.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import Header from "../component/Header";
 import ImageCard from "../component/ImageCard";
 import { useNavigate, useParams } from "react-router-dom";
+import Button from "../component/Button";
 
 export default function Review(){
 
@@ -10,16 +11,23 @@ export default function Review(){
       const IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500";
   const API_KEY = import.meta.env.VITE_TMDB_API_KEY;
   const API_URL = `https://api.themoviedb.org/3/movie/${id}?api_key=${API_KEY}&language=ko-KR&page=1`;
-const [movie, SetMovies] = useState(null)
+const [movie, setMovies] = useState(null)
+const [comments, setComments] = useState([])
+const [newComment, setNewComment] = useState("")
 
-
+// 댓글함수
+const handleAddComment = () => {
+  if(newComment.trim() === "") return;
+  setComments([...comments, {id: Date.now(), text: newComment}]);
+  setNewComment("")
+}
   useEffect(() => {
     setTimeout(() => {
     }, 100);
     fetch(API_URL)
       .then((res) => res.json())
       .then((data) => {
-        SetMovies(data);
+        setMovies(data)
       })
       .catch((err) => console.error("데이터 로드 실패!", err));
   }, [id]);
@@ -29,14 +37,35 @@ const [movie, SetMovies] = useState(null)
             <Header/>
 {movie && (
     <main className="pt-24 flex justify-center">
-    <div className="p-6 bg-slate-800 rounded-3xl shadow-2xl max-w-sm transition-transform " key={id}>
+    <div className="p-6 bg-slate-800 rounded-2xl rounded-s-rg shadow-2xl max-w-sm transition-transform " >
       <ImageCard
         imageUrl={`${IMAGE_BASE_URL}${movie.poster_path}`}
         title={movie.title}
         rating={movie.vote_average?.toFixed(1)}
         />
       <p className="text-lg text-slate-300 leading-relaxed">{movie.overview || "등록된 줄거리가 없습니다"}
-</p>      </div>
+</p>      
+</div>
+
+{/* 댓글영역 */}
+<div className="p-6 bg-[#1e293b] w-full rounded-xl md:w-1/2 ">
+<h3 className="text-xl font-bold mb-4">댓글({comments.length})</h3>
+<input type="text" value={newComment} className="p-1 rounded-xl text-white border-2"
+placeholder="댓글을 입력하세요"
+ onChange={(e) => setNewComment(e.target.value)}/>
+<button className="px-2" onClick={handleAddComment}>등록</button>
+
+{/* 댓글입력기능 */}
+<ul className="space-y-3 mt-6">
+  {comments.map((comment) => (
+  <li 
+  key={comment.id} 
+  className="p-4 bg-slate-800 rounded-lg border border-slate-700 shadow-sm">
+    <p className="text-slate-200">{comment.text}</p>
+    <span className="text-xs text-slate-500 block mt-2">{new Date(comment.id).toLocaleDateString()}</span></li>
+))}</ul>
+</div>
+
       </main>
     )}
         </div>

--- a/src/component/Avatar.jsx
+++ b/src/component/Avatar.jsx
@@ -1,0 +1,7 @@
+export default function Avatar({ imageUrl, altText }) {
+  return (
+    <div className="avatar-container">
+      <img src={imageUrl} alt={altText} className="avatar-image rounded-full w-12 h-12 object-cover" />
+    </div>
+  );
+}

--- a/src/component/ImageCard.jsx
+++ b/src/component/ImageCard.jsx
@@ -1,7 +1,7 @@
 const ImageCard = ({ imageUrl, title, onButtonClick, rating }) => {
     return (
         <div className="card-container cursor-pointer" onClick={onButtonClick}>
- <img src={imageUrl} alt={title} className="w-full h-auto object-cover object-contain rounded-lg"/>
+ <img src={imageUrl} alt={title} className="w-full h-auto object-cover rounded-lg"/>
  <div className="flex flex-col gap-1">
   <h3 className="text-lg font-bold truncate">{title}</h3>
 


### PR DESCRIPTION
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/dfff3e19-7f3b-47de-9a3f-bc3854c31c1f" />
상세페이지

<img width="1910" height="1073" alt="image" src="https://github.com/user-attachments/assets/d8785b9e-4792-4a08-832f-14c2c26c0e92" />
댓글 작성시 나오는 ui

댓글영역을 따로 나누고 위에 댓글의 갯수를 표시하기 위해 댓글({comments.length}) 로 댓글의 갯수에 따라 횟수가 나오게 설정해놓았습니다

댓글입력기능은 댓글을 여러개 구현해야하기 때문에 maps를 이용했고 

댓글마다의 id가 필요하기 때문에 li안에 key값을 주고 그 안에 commet.id를 줬습니다

실제 텍스트의 내용이 호출이 되어야하기 때문에 p태그 안에 comment.text로 출력이 되도록 주었습니다.

댓글을 호출하고 다시 메인으로 나갔다 들어오면 초기화 되는 현상이 있는데 이건 
onChange가 사용자의 글자를 가로채서 newComment에 넣음
등록 버튼이 보관함 글자를 꺼내서 전체 리스트 comments 에 합침
useEffect가 리스트가 바뀐 걸 보고 냉큼 브라우저 저장소 localStronge 에 업데이트함

이 구조로 인해 사용자가 나중에 다시 들어왔을때 useState 초기값 설정 부분에서 localStronge,getItem으로 데이터를 다시 꺼내올 수 있는 것이다



